### PR TITLE
[WIP: レビュアー, アサイニー編集中]PRのレビュアーアサイン時、approve時のアサイニーを自動で割り振る

### DIFF
--- a/workflows/assign-reviewer-as-pr-assignee.yml
+++ b/workflows/assign-reviewer-as-pr-assignee.yml
@@ -1,0 +1,20 @@
+name: PRにレビュアーが振られたらAssigneeにも振る
+
+on:
+  pull_request:
+    types: [review_requested]
+
+jobs:
+  assign-assignee-when-pr-is-ready-for-review:
+    runs-on: ubuntu-latest
+    # github-copilot がAssigneeにならないようにはじく
+    if: ${{ github.event.requested_reviewer != null && github.event.requested_reviewer != 'github-copilot' }}
+    steps:
+      - name: Assign reviewer as assignee
+        run: >
+          gh pr edit ${{ github.event.number }}
+          --remove-assignee $(gh pr view ${{ github.event.number }} --json assignees -q ".assignees[].login" | jq -r '.[]' | tr '\n' ',' | sed 's/,$//')
+          --add-assignee ${{ github.event.requested_reviewer.login }}
+          --repo $GITHUB_REPOSITORY
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/return-assignee-when-pr-is-approved.yml
+++ b/workflows/return-assignee-when-pr-is-approved.yml
@@ -1,0 +1,19 @@
+name: PRが承認されたらAssigneeをownerに戻す
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  return-assignee-when-pr-is-approved:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.review.state == 'approved' }}
+    steps:
+      - name: Assign owner as assignee
+        run: >
+          gh pr edit ${{ github.event.pull_request.number }}
+          --remove-assignee ${{ github.event.pull_request.assignee.login }}
+          --add-assignee ${{ github.event.pull_request.user.login }}
+          --repo $GITHUB_REPOSITORY
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

https://github.com/odt/OperatorWeb/issues/17083

## 目的

- タイトルの通り(割り振り忘れの防止)

## 受入基準

- このリポジトリで自動割り当てが成功すること
- 他のリポジトリ(OperatorWeb, ReportingWebなど)で自動割り当てが成功すること

<!-- I want to review in Japanese. -->
