### PR TITLE
Revert "Github Copilot コードレビューが日本語になるようにする"

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,3 @@
-<!-- I want to review in Japanese. -->
-
 <!-- 関連Issue -->
 
 ## 目的
@@ -23,5 +21,3 @@
 <!-- 必要に応じて受入基準を確かめるための手順を補足する -->
 
 ## 他
-
-<!-- I want to review in Japanese. -->


### PR DESCRIPTION
- https://github.com/odt/OperatorWeb/issues/16794

## 目的

Copilot コードレビュー にカスタムプロンプトが渡せるようになったようなので、日本語でレビューしてもらうためにPRテンプレートに入れていた文言を無くす。

[Copilot code review: Customization for all - GitHub Changelog](https://github.blog/changelog/2025-06-13-copilot-code-review-customization-for-all/)

![image](https://github.com/user-attachments/assets/46537b35-7422-4160-a2de-3e97c669964c)


## 受入基準

https://github.com/odt/OperatorWeb/pull/17505 でトップコメントから日本語でレビューしてもらうために入れていた文言を消してPRを ready for review にして動作確認したところ、日本語でレビューしてくれることを確認済みです。